### PR TITLE
removing some redundant module prefixing

### DIFF
--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -196,7 +196,7 @@ function islandora_solr_islandora_basic_collection_build_manage_object(array $fo
       '#access' => TRUE,
       '#type' => 'fieldset',
       '#title' => t('Set Solr Sort String'),
-      'form' => \Drupal::formBuilder()->getForm('Drupal\islandora_solr\Form\IslandoraSolrManageCollectionSortForm', $object),
+      'form' => \Drupal::formBuilder()->getForm('Drupal\islandora_solr\Form\ManageCollectionSortForm', $object),
     ];
     return $form;
   }

--- a/islandora_solr.routing.yml
+++ b/islandora_solr.routing.yml
@@ -10,55 +10,48 @@ islandora_solr.admin_index_settings:
   path: /admin/config/islandora/search
   defaults:
     _title: 'Solr index'
-    _form: \Drupal\islandora_solr\Form\IslandoraSolrAdminIndexSettings
+    _form: \Drupal\islandora_solr\Form\AdminIndexSettings
   requirements:
     _permission: 'administer islandora solr'
 islandora_solr.admin_settings:
   path: /admin/config/islandora/search/settings
   defaults:
     _title: 'Solr settings'
-    _form: \Drupal\islandora_solr\Form\IslandoraSolrAdminSettings
+    _form: \Drupal\islandora_solr\Form\AdminSettings
   requirements:
     _permission: 'administer islandora solr'
 islandora_solr.admin_breadcrumbs_settings:
   path: /admin/islandora/search/islandora_solr/breadcrumbs
   defaults:
     _title: 'Solr breadcrumbs'
-    _form: \Drupal\islandora_solr\Form\IslandoraSolrAdminBreadcrumbsSettings
+    _form: \Drupal\islandora_solr\Form\AdminBreadcrumbsSettings
   requirements:
     _permission: 'administer islandora solr'
 islandora_solr.configure_result_field:
   path: /islandora_solr/result_field/{solr_field}
   defaults:
     _title: 'Configure field'
-    _form: \Drupal\islandora_solr\Form\IslandoraSolrConfigureResultField
-  requirements:
-    _permission: 'administer islandora solr'
-islandora_solr.configure_search_field:
-  path: /islandora_solr/search_field/{solr_field}
-  defaults:
-    _title: 'Configure field'
-    _form: \Drupal\islandora_solr\Form\IslandoraSolrConfigureSearchField
+    _form: \Drupal\islandora_solr\Form\ConfigureResultField
   requirements:
     _permission: 'administer islandora solr'
 islandora_solr.configure_facet_field:
   path: /islandora_solr/facet_field/{solr_field}
   defaults:
     _title: 'Configure field'
-    _form: \Drupal\islandora_solr\Form\IslandoraSolrConfigureFacetField
+    _form: \Drupal\islandora_solr\Form\ConfigureFacetField
   requirements:
     _permission: 'administer islandora solr'
 islandora_solr.configure_sort_or_search_field:
   path: /islandora_solr/sort_or_field/{field_type}/{solr_field}
   defaults:
     _title: 'Configure field'
-    _form: \Drupal\islandora_solr\Form\IslandoraSolrConfigureSortOrSearchField
+    _form: \Drupal\islandora_solr\Form\ConfigureSortOrSearchField
   requirements:
     _permission: 'administer islandora solr'
 islandora_solr.autocomplete_luke:
   path: /islandora_solr/autocomplete_luke
   defaults:
     _title: 'Islandora Solr Luke autocomplete'
-    _controller: '\Drupal\islandora_solr\Controller\DefaultController::islandoraSolrAutocompleteLuke'
+    _controller: '\Drupal\islandora_solr\Controller\DefaultController::autocompleteLuke'
   requirements:
     _permission: 'administer islandora solr'

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -140,7 +140,7 @@ class DefaultController extends ControllerBase {
   /**
    * Admin autocomplete callback which returns solr fields from Luke.
    */
-  public function islandoraSolrAutocompleteLuke(Request $request) {
+  public function autocompleteLuke(Request $request) {
     module_load_include('inc', 'islandora_solr', 'includes/luke');
     $string = $request->query->get('q');
     $luke = islandora_solr_get_luke();

--- a/src/Form/AdminBreadcrumbsSettings.php
+++ b/src/Form/AdminBreadcrumbsSettings.php
@@ -9,7 +9,7 @@ use Drupal\Core\Url;
 /**
  * Display admin form for breadcrumb field choice.
  */
-class IslandoraSolrAdminBreadcrumbsSettings extends ConfigFormBase {
+class AdminBreadcrumbsSettings extends ConfigFormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Form/AdminIndexSettings.php
+++ b/src/Form/AdminIndexSettings.php
@@ -10,7 +10,7 @@ use Drupal\Core\Url;
 /**
  * Islandora Solr index admin form.
  */
-class IslandoraSolrAdminIndexSettings extends ConfigFormBase {
+class AdminIndexSettings extends ConfigFormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Form/AdminSettings.php
+++ b/src/Form/AdminSettings.php
@@ -10,7 +10,7 @@ use Drupal\islandora\Form\ModuleHandlerAdminForm;
 /**
  * Administration setting form.
  */
-class IslandoraSolrAdminSettings extends ModuleHandlerAdminForm {
+class AdminSettings extends ModuleHandlerAdminForm {
 
   /**
    * {@inheritdoc}

--- a/src/Form/ConfigureFacetField.php
+++ b/src/Form/ConfigureFacetField.php
@@ -11,7 +11,7 @@ use Drupal\Core\Ajax\ReplaceCommand;
 /**
  * Form to configure a Solr facet field.
  */
-class IslandoraSolrConfigureFacetField extends FormBase {
+class ConfigureFacetField extends FormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Form/ConfigureResultField.php
+++ b/src/Form/ConfigureResultField.php
@@ -11,7 +11,7 @@ use Drupal\Core\Ajax\ReplaceCommand;
 /**
  * Form to configure a Solr result field.
  */
-class IslandoraSolrConfigureResultField extends FormBase {
+class ConfigureResultField extends FormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Form/ConfigureSortOrSearchField.php
+++ b/src/Form/ConfigureSortOrSearchField.php
@@ -11,7 +11,7 @@ use Drupal\Core\Ajax\ReplaceCommand;
 /**
  * Form to configure a Solr sort or search field.
  */
-class IslandoraSolrConfigureSortOrSearchField extends FormBase {
+class ConfigureSortOrSearchField extends FormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Form/IslandoraSolrAdminSettings.php
+++ b/src/Form/IslandoraSolrAdminSettings.php
@@ -5,12 +5,12 @@ namespace Drupal\islandora_solr\Form;
 use PDO;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\islandora\Form\IslandoraModuleHandlerAdminForm;
+use Drupal\islandora\Form\ModuleHandlerAdminForm;
 
 /**
  * Administration setting form.
  */
-class IslandoraSolrAdminSettings extends IslandoraModuleHandlerAdminForm {
+class IslandoraSolrAdminSettings extends ModuleHandlerAdminForm {
 
   /**
    * {@inheritdoc}

--- a/src/Form/ManageCollectionSortForm.php
+++ b/src/Form/ManageCollectionSortForm.php
@@ -9,7 +9,7 @@ use Drupal\Core\Url;
 /**
  * Form to set collection sort string.
  */
-class IslandoraSolrManageCollectionSortForm extends FormBase {
+class ManageCollectionSortForm extends FormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Block/Query.php
+++ b/src/Plugin/Block/Query.php
@@ -16,7 +16,7 @@ use Drupal\islandora_solr\IslandoraSolrResults;
  *   admin_label = @Translation("Islandora query"),
  * )
  */
-class IslandoraSolrQuery extends BlockBase {
+class Query extends BlockBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Redundant Module Prefixing

# What does this Pull Request do?

Removes redundant module prefixing from method and class names.

Depends on https://github.com/discoverygarden/islandora/pull/8