### PR TITLE
Removing D7 menuism. Will revisit as needed.

### DIFF
--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -57,9 +57,12 @@ function islandora_solr_get_breadcrumbs_recursive($pid, array &$context = NULL) 
     $context['root'] = $root;
   }
   if ($pid == $context['root']) {
+    $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+    $islandora_links = $menu_link_manager->loadLinksByRoute('islandora.view_default_object');
+    $islandora_link = reset($islandora_links);
     return [
       Link::createFromRoute(t('Home'), '<front>'),
-      Link::createFromRoute(t('Islandora Repository'), 'islandora.view_default_object'),
+      Link::createFromRoute($islandora_link->getTitle(), 'islandora.view_default_object'),
     ];
   }
   else {

--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -57,19 +57,9 @@ function islandora_solr_get_breadcrumbs_recursive($pid, array &$context = NULL) 
     $context['root'] = $root;
   }
   if ($pid == $context['root']) {
-    $title = 'Islandora Repository';
-    $mlid = db_select('menu_links', 'ml')
-      ->condition('ml.link_path', 'islandora')
-      ->fields('ml', ['mlid'])
-      ->execute()
-      ->fetchField();
-    if ($mlid) {
-      $link = menu_link_load($mlid);
-      $title = (isset($link['title']) ? $link['title'] : $title);
-    }
     return [
       Link::createFromRoute(t('Home'), '<front>'),
-      Link::createFromRoute($title, 'islandora.view_default_object'),
+      Link::createFromRoute(t('Islandora Repository'), 'islandora.view_default_object'),
     ];
   }
   else {


### PR DESCRIPTION
Porting D8 breadcrumbs.

* [requires](https://github.com/discoverygarden/islandora/pull/14)
* [issue](https://github.com/discoverygarden/islandora/issues/13)

# How should this be tested?

Switch breadcrumb generation to Islandora Solr. Visit a nested object and view hierarchical breadcrumbs.
