### PR TITLE
Update islandora_solr_facets.js

### DIFF
--- a/js/islandora_solr_facets.js
+++ b/js/islandora_solr_facets.js
@@ -168,6 +168,10 @@
             $(this).find('.slider-popup-to-wrapper').stop(false, true).fadeOut('slow');
           });
 
+          // Add aria-label for WCAG 2.0 compliance.
+          $(sliderId + ' > a:eq(0)').attr('aria-label', "From");
+          $(sliderId + ' > a:eq(1)').attr('aria-label', "To");
+
           // Prepare flot data.
           var d1 = [];
           for (var i = 0; i <= sliderMax - 1; i += 1) {


### PR DESCRIPTION
Adding fix for WCAG 2.0 standards for slider handles.
#WCAG Islandora Solr Search

aXe accessibility engine: https://www.deque.com/axe/
Web Accessibility inititive: https://www.w3.org/WAI/intro/wcag

# What does this Pull Request do?
Adds 'aria-label' attribute to date slider handles for use with screen readers in an effort to comply with WCAG 2.0 requirements

# What's new?
updated islandora_solr_facets.js file to add the proper handles.

# How should this be tested?

The easiest way to test these changes locally:
- install the aXe browser plugin in your browser of choice (found here: https://www.deque.com/axe/).
- Recommended: Enable the ‘AT Subtheme’ found in the Adaptive Core (https://www.drupal.org/project/adaptivetheme). This theme is the closest to matching wcag 2.0 requirements i could find.
- Run the aXe tool on a search results page with a date range facet, and inspect the dom using a toolbox of your choice for WCAG 2.0 violations in this modules returned code.

This pull request is intended to correspond with an associated and related D7 pull:
https://github.com/Islandora/islandora_solr_search/pull/336

# Interested parties
Tag @discoverygarden/dgi 