### PR TITLE
Update IslandoraAdvancedSearch.php

### DIFF
--- a/src/Form/IslandoraAdvancedSearch.php
+++ b/src/Form/IslandoraAdvancedSearch.php
@@ -142,6 +142,7 @@ class IslandoraAdvancedSearch extends FormBase {
       $term[$build]['field'] = [
         '#title' => $this->t('Field'),
         '#type' => 'select',
+        '#title_display' => 'invisible',
         '#default_value' => isset($value['field']) ? $value['field'] : NULL,
         '#options' => islandora_solr_get_fields('search_fields'),
       ];
@@ -192,6 +193,8 @@ class IslandoraAdvancedSearch extends FormBase {
             '#type' => 'select',
             '#prefix' => '<div>',
             '#suffix' => '</div>',
+            '#title' => t('Operator'),
+            '#title_display' => 'invisible',
             '#default_value' => isset($value['boolean']) ? $value['boolean'] : 'AND',
             '#options' => [
               'AND' => 'AND',

--- a/src/Form/IslandoraAdvancedSearch.php
+++ b/src/Form/IslandoraAdvancedSearch.php
@@ -142,7 +142,6 @@ class IslandoraAdvancedSearch extends FormBase {
       $term[$build]['field'] = [
         '#title' => $this->t('Field'),
         '#type' => 'select',
-        '#title_display' => 'invisible',
         '#default_value' => isset($value['field']) ? $value['field'] : NULL,
         '#options' => islandora_solr_get_fields('search_fields'),
       ];


### PR DESCRIPTION
Adding fix for WCAG 2.0 standards for advanced search fields
#WCAG Islandora Solr Search

aXe accessibility engine: https://www.deque.com/axe/
Web Accessibility inititive: https://www.w3.org/WAI/intro/wcag

# What's new?
Adds titles and title display property to the advanced search render array.

# How should this be tested?

The easiest way to test these changes locally:
- install the aXe browser plugin in your browser of choice (found here: https://www.deque.com/axe/).
- Recommended: Enable the ‘AT Subtheme’ found in the Adaptive Core (https://www.drupal.org/project/adaptivetheme). This theme is the closest to matching wcag 2.0 requirements i could find.
- Run the aXe tool on a search results page with a date range facet, and inspect the dom using a toolbox of your choice for WCAG 2.0 violations in this modules returned code.

This pull request is intended to correspond with an associated and related D7 pull:
https://github.com/Islandora/islandora_solr_search/pull/336

# Interested parties
Tag @willtp87 