### PR TITLE
handling ajax error on php 7.1+ when adding the first display field.

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -82,8 +82,6 @@ function islandora_solr_admin_settings_fields(FormStateInterface $form_state, ar
       // Add new field to values.
       if ($solr_field_error == NULL) {
         $form_state_terms = $form_state->getValue(['islandora_solr_' . $field_type, 'terms']);
-        // @XXX: As of PHP 7.1.0, applying the empty index operator on a string
-        // throws a fatal error.
         $form_state_terms = $form_state_terms === '' ? [] : $form_state_terms;
         $form_state_terms[] = ['solr_field' => $add_solr_field];
         $form_state->setValue(['islandora_solr_' . $field_type, 'terms'], $form_state_terms);

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -82,6 +82,9 @@ function islandora_solr_admin_settings_fields(FormStateInterface $form_state, ar
       // Add new field to values.
       if ($solr_field_error == NULL) {
         $form_state_terms = $form_state->getValue(['islandora_solr_' . $field_type, 'terms']);
+        // @XXX: As of PHP 7.1.0, applying the empty index operator on a string
+        // throws a fatal error.
+        $form_state_terms = $form_state_terms === '' ? [] : $form_state_terms;
         $form_state_terms[] = ['solr_field' => $add_solr_field];
         $form_state->setValue(['islandora_solr_' . $field_type, 'terms'], $form_state_terms);
       }


### PR DESCRIPTION
Addressing that on PHP 7.1+ adding a display field in the Solr config would not work.