### PR TITLE
Fix field permission application, DRY out form code and config schema

### DIFF
--- a/config/schema/islandora_solr.data_types.schema.yml
+++ b/config/schema/islandora_solr.data_types.schema.yml
@@ -1,4 +1,4 @@
-islandora_solr.base_field:
+islandora_solr.base_fields:
   type: mapping
   label: Base field
   mapping:
@@ -18,7 +18,7 @@ islandora_solr.base_field:
         type: string
         nullable: true
 islandora_solr.result_fields:
-  type: islandora_solr.base_field
+  type: islandora_solr.base_fields
   label: Display Result Field
   mapping:
     snippet:
@@ -42,10 +42,10 @@ islandora_solr.result_fields:
     replace_pid_with_label:
       type: boolean
 islandora_solr.sort_fields:
-  type: islandora_solr.base_field
+  type: islandora_solr.base_fields
   label: Sort Field
 islandora_solr.facet_fields:
-  type: islandora_solr.base_field
+  type: islandora_solr.base_fields
   label: Facet Field
   mapping:
     sort_by:
@@ -77,5 +77,5 @@ islandora_solr.facet_fields:
     pid_object_label:
       type: boolean
 islandora_solr.search_fields:
-  type: islandora_solr.base_field
+  type: islandora_solr.base_fields
   label: Advanced Search Field

--- a/config/schema/islandora_solr.data_types.schema.yml
+++ b/config/schema/islandora_solr.data_types.schema.yml
@@ -1,6 +1,6 @@
-islandora_solr.result_fields:
+islandora_solr.base_field:
   type: mapping
-  label: Display Result Field
+  label: Base field
   mapping:
     solr_field:
       type: string
@@ -9,6 +9,18 @@ islandora_solr.result_fields:
       type: label
     weight:
       type: integer
+    enable_permissions:
+      type: boolean
+    permissions:
+      type: sequence
+      nullable: true
+      sequence:
+        type: string
+        nullable: true
+islandora_solr.result_fields:
+  type: islandora_solr.base_field
+  label: Display Result Field
+  mapping:
     snippet:
       type: boolean
     truncation_type:
@@ -29,44 +41,13 @@ islandora_solr.result_fields:
       type: boolean
     replace_pid_with_label:
       type: boolean
-    enable_permissions:
-      type: boolean
-    permissions:
-      type: sequence
-      nullable: true
-      sequence:
-        type: integer
-        nullable: true
 islandora_solr.sort_fields:
-  type: mapping
+  type: islandora_solr.base_field
   label: Sort Field
-  mapping:
-    solr_field:
-      type: string
-      nullable: false
-    label:
-      type: label
-    weight:
-      type: integer
-    enable_permissions:
-      type: boolean
-    permissions:
-      type: sequence
-      nullable: true
-      sequence:
-        type: integer
-        nullable: true
 islandora_solr.facet_fields:
-  type: mapping
+  type: islandora_solr.base_field
   label: Facet Field
   mapping:
-    solr_field:
-      type: string
-      nullable: false
-    label:
-      type: label
-    weight:
-      type: integer
     sort_by:
       type: string
     date_facet_format:
@@ -95,30 +76,6 @@ islandora_solr.facet_fields:
       type: string
     pid_object_label:
       type: boolean
-    enable_permissions:
-      type: boolean
-    permissions:
-      type: sequence
-      nullable: true
-      sequence:
-        type: integer
-        nullable: true
 islandora_solr.search_fields:
-  type: mapping
+  type: islandora_solr.base_field
   label: Advanced Search Field
-  mapping:
-    solr_field:
-      type: string
-      nullable: false
-    label:
-      type: label
-    weight:
-      type: integer
-    enable_permissions:
-      type: boolean
-    permissions:
-      type: sequence
-      nullable: true
-      sequence:
-        type: integer
-        nullable: true

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -9,6 +9,7 @@ use Drupal\Core\Url;
 use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\SortArray;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\user\RoleInterface;
 
 /**
  * Generates fields for the admin fields table.
@@ -402,36 +403,34 @@ function islandora_solr_get_admin_permissions_fieldset($permissions, array $perm
  * Returns an array of role IDs to disable checkboxes.
  */
 function _islandora_solr_permissions_disable() {
-  $user_roles = array_keys(user_roles());
-  $permissions_solr = array_keys(user_roles(FALSE, 'search islandora solr'));
-  $permissions_disable = array_diff($user_roles, $permissions_solr);
+  $user_roles = user_roles();
+  $permissions_solr = user_roles(FALSE, 'search islandora solr');
+  $permissions_disable = array_diff_key($user_roles, $permissions_solr);
   // If authenticated users have permission exclude all authenticated users
   // fields from the disable list.
-  if (in_array('2', $permissions_solr)) {
-    foreach ($permissions_disable as $key => $rid) {
-      if ($rid != '1') {
-        unset($permissions_disable[$key]);
-      }
-    }
+  if (isset($permissions_solr[RoleInterface::AUTHENTICATED_ID])) {
+    $permissions_disable = isset($permissions_disable[RoleInterface::ANONYMOUS_ID]) ?
+      [
+        RoleInterface::ANONYMOUS_ID => $permissions_disable[RoleInterface::ANONYMOUS_ID],
+      ] :
+      [];
   }
-  return $permissions_disable;
+  return array_keys($permissions_disable);
 }
 
 /**
  * Returns an array of role id's to set default values for checkboxes.
  */
 function _islandora_solr_permissions_default() {
-  $user_roles = array_keys(user_roles());
-  $permissions_solr = array_keys(user_roles(FALSE, 'search islandora solr'));
-  $permissions_default = array_intersect($user_roles, $permissions_solr);
+  $user_roles = user_roles();
+  $permissions_solr = user_roles(FALSE, 'search islandora solr');
+  $permissions_default = array_intersect_key($user_roles, $permissions_solr);
   // If authenticated users have permission include all authenticated users
   // fields to the default list.
-  if (in_array('2', $permissions_solr)) {
-    foreach ($user_roles as $rid) {
-      if ($rid != '1' && !in_array($rid, $permissions_default)) {
-        $permissions_default[] = $rid;
-      }
-    }
+  if (isset($permissions_solr[RoleInterface::AUTHENTICATED_ID])) {
+    $permissions_default += array_filter($user_roles, function ($role) {
+      return $role->id() != RoleInterface::ANONYMOUS_ID;
+    });
   }
-  return $permissions_default;
+  return array_keys($permissions_default);
 }

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -36,10 +36,10 @@ function islandora_solr_get_field_configuration($field_type, $field_name) {
  */
 function islandora_solr_get_default_field_configuration($solr_field, $field_type, array $defaults = []) {
   $field_config_class = [
-    'facet_fields' => ConfigureFacetField::class,
-    'sort_fields' => ConfigureSortField::class,
-    'result_fields' => ConfigureResultField::class,
-    'search_fields' => ConfigureSearchField::class,
+    ConfigureFacetField::getFieldType() => ConfigureFacetField::class,
+    ConfigureSortField::getFieldType() => ConfigureSortField::class,
+    ConfigureResultField::getFieldType() => ConfigureResultField::class,
+    ConfigureSearchField::getFieldType() => ConfigureSearchField::class,
   ];
   $config = call_user_func_array([$field_config_class[$field_type], 'getFieldConfiguration'], [$defaults]);
   $config['solr_field'] = $solr_field;

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -122,7 +122,7 @@ function _islandora_solr_filter_fields(array $records = []) {
 
   $default_permission_info = [
     'enable_permissions' => FALSE,
-    'permissions' => [],
+    'permissions' => NULL,
   ];
 
   $filter = function (array $record) use ($default_permission_info, $user) {

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -109,15 +109,20 @@ function islandora_solr_update_8000() {
     $field_config = islandora_solr_get_default_field_configuration($field['solr_field'], $field['field_type'], $settings);
     // Don't need to hang onto this since the configs are split by type.
     unset($field_config['field_type']);
-    // Permissions now nullable.
-    if (!isset($field_config['permissions']) || !($field_config['permissions'])) {
-      $field_config['permissions'] = NULL;
-      // Tracking this separate from the permissions config now.
-      $field_config['enable_permissions'] = FALSE;
+
+    // XXX: Given how role identification has changed between D7 and D8, where
+    // D7 used numeric IDs while D8 uses machine names, and it is unknown at
+    // time of writing how to discover/hook into the mapping, let's just drop
+    // the permission configuration.
+    if (isset($field_config['permissions']) && $field_config['permissions']) {
+      \Drupal::logger('islandora_solr-7to8')->warning(\Drupal::t("@type.@field had permissions associated which we have not migrated.", [
+        '@type' => $field['field_type'],
+        '@field' => $field['solr_field'],
+      ]));
     }
-    else {
-      $field_config['enable_permissions'] = TRUE;
-    }
+    $field_config['enable_permissions'] = FALSE;
+    $field_config['permissions'] = NULL;
+
     $field_config['weight'] = (int) $field['weight'];
     $machine_name = ConfigFieldFormBase::generateFieldKey($field['solr_field']);
     $config->set("{$field['field_type']}.{$machine_name}", $field_config);

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -115,7 +115,7 @@ function islandora_solr_update_8000() {
     // time of writing how to discover/hook into the mapping, let's just drop
     // the permission configuration.
     if (isset($field_config['permissions']) && $field_config['permissions']) {
-      \Drupal::logger('islandora_solr-7to8')->warning(\Drupal::t("@type.@field had permissions associated which we have not migrated.", [
+      \Drupal::logger('islandora_solr-7to8')->warning(t("@type.@field had permissions associated which we have not migrated.", [
         '@type' => $field['field_type'],
         '@field' => $field['solr_field'],
       ]));

--- a/src/Form/ConfigFieldFormBase.php
+++ b/src/Form/ConfigFieldFormBase.php
@@ -36,7 +36,7 @@ abstract class ConfigFieldFormBase extends ConfigFormBase {
    *   One of the field types, either 'result_fields', 'facet_fields',
    *   'sort_fields', or 'search_fields'.
    */
-  protected static function getFieldType() {
+  public static function getFieldType() {
     return static::FIELD_TYPE . 's';
   }
 

--- a/src/Form/ConfigFieldFormBase.php
+++ b/src/Form/ConfigFieldFormBase.php
@@ -74,7 +74,7 @@ abstract class ConfigFieldFormBase extends ConfigFormBase {
     return [
       'label' => '',
       'enable_permissions' => FALSE,
-      'permissions' => [],
+      'permissions' => NULL,
       'weight' => 0,
     ];
   }

--- a/src/Form/ConfigFieldFormBase.php
+++ b/src/Form/ConfigFieldFormBase.php
@@ -89,7 +89,7 @@ abstract class ConfigFieldFormBase extends ConfigFormBase {
     $form['#suffix'] = '</div>';
 
     $form_state->setStorage(['solr_field' => $solr_field]);
-    $values = islandora_solr_get_field_configuration($this->getFieldType(), $solr_field);
+    $values = islandora_solr_get_field_configuration(static::getFieldType(), $solr_field);
 
     $form['options'] = [
       '#type' => 'container',
@@ -173,7 +173,7 @@ abstract class ConfigFieldFormBase extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $field_type = $this->getFieldType();
+    $field_type = static::getFieldType();
     $field_name = $this->getRequest()->get('solr_field');
     $field_key = static::generateFieldKey($field_name);
     $values = $form_state->getValues();

--- a/src/Form/ConfigureFacetField.php
+++ b/src/Form/ConfigureFacetField.php
@@ -20,7 +20,7 @@ class ConfigureFacetField extends ConfigFieldFormBase {
     $form['#suffix'] = '</div>';
 
     $form_state->setStorage(['solr_field' => $solr_field]);
-    $values = islandora_solr_get_field_configuration($this->getFieldType(), $solr_field);
+    $values = islandora_solr_get_field_configuration(static::getFieldType(), $solr_field);
 
     $form['options'] = [
       '#type' => 'container',

--- a/src/Form/ConfigureFacetField.php
+++ b/src/Form/ConfigureFacetField.php
@@ -8,70 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
  * Form to configure a Solr facet field.
  */
 class ConfigureFacetField extends ConfigFieldFormBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'islandora_solr_configure_facet_field_form';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getFieldType() {
-    return 'facet_fields';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getFieldConfiguration(array $solr_field_settings) {
-    module_load_include('inc', 'islandora_solr', 'includes/admin');
-    $fields = array_combine([
-      'label',
-      'range_facet_select',
-      'range_facet_variable_gap',
-      'range_facet_start',
-      'range_facet_end',
-      'range_facet_gap',
-      'date_facet_format',
-      'range_facet_slider_enabled',
-      'range_facet_slider_color',
-      'date_filter_datepicker_enabled',
-      'date_filter_datepicker_range',
-      'pid_object_label',
-      'boolean_facet_true_replacement',
-      'boolean_facet_false_replacement',
-      'sort_by',
-      'enable_permissions',
-      'permissions',
-    ], [
-      'label',
-      'range_facet_select',
-      'range_facet_variable_gap',
-      'range_facet_start',
-      'range_facet_end',
-      'range_facet_gap',
-      'date_facet_format',
-      'range_facet_slider_enabled',
-      'range_facet_slider_color',
-      'date_filter_datepicker_enabled',
-      'date_filter_datepicker_range',
-      'pid_object_label',
-      'boolean_facet_true_replacement',
-      'boolean_facet_false_replacement',
-      'sort_by',
-      'enable_permissions',
-      'permissions',
-    ]);
-    $relevant_values = array_intersect_key($solr_field_settings, $fields);
-    $relevant_values['label'] = isset($relevant_values['label']) ?
-      trim($relevant_values['label']) :
-      '';
-    $relevant_values['weight'] = isset($solr_field_settings['weight']) ? (int) $solr_field_settings['weight'] : 0;
-    return $relevant_values;
-  }
+  const FIELD_TYPE = 'facet_field';
 
   /**
    * {@inheritdoc}
@@ -83,7 +20,7 @@ class ConfigureFacetField extends ConfigFieldFormBase {
     $form['#suffix'] = '</div>';
 
     $form_state->setStorage(['solr_field' => $solr_field]);
-    $values = islandora_solr_get_field_configuration('facet_fields', $solr_field);
+    $values = islandora_solr_get_field_configuration($this->getFieldType(), $solr_field);
 
     $form['options'] = [
       '#type' => 'container',

--- a/src/Form/ConfigureResultField.php
+++ b/src/Form/ConfigureResultField.php
@@ -38,7 +38,7 @@ class ConfigureResultField extends ConfigFieldFormBase {
     $form['#suffix'] = '</div>';
 
     $form_state->setStorage(['solr_field' => $solr_field]);
-    $values = islandora_solr_get_field_configuration($this->getFieldType(), $solr_field);
+    $values = islandora_solr_get_field_configuration(static::getFieldType(), $solr_field);
 
     $form['options'] = [
       '#type' => 'container',

--- a/src/Form/ConfigureResultField.php
+++ b/src/Form/ConfigureResultField.php
@@ -8,42 +8,24 @@ use Drupal\Core\Form\FormStateInterface;
  * Form to configure a Solr result field.
  */
 class ConfigureResultField extends ConfigFieldFormBase {
+  const FIELD_TYPE = 'result_field';
 
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
-    return 'islandora_solr_configure_result_field_form';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getFieldType() {
-    return 'result_fields';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getFieldConfiguration(array $solr_field_settings) {
-    module_load_include('inc', 'islandora_solr', 'includes/admin');
+  protected static function fieldConfigurationDefaults() {
     return [
-      'label' => isset($solr_field_settings['label']) ? trim($solr_field_settings['label']) : '',
-      'snippet' => isset($solr_field_settings['snippet']) ? (bool) $solr_field_settings['snippet'] : FALSE,
-      'date_format' => isset($solr_field_settings['date_format']) ? trim($solr_field_settings['date_format']) : '',
-      'truncation_type' => isset($solr_field_settings['truncation_type']) ? trim($solr_field_settings['truncation_type']) : 'separate_value_option',
-      'maximum_length' => isset($solr_field_settings['maximum_length']) ? (int) trim($solr_field_settings['maximum_length']) : 0,
-      'add_ellipsis' => isset($solr_field_settings['add_ellipsis']) ? (bool) $solr_field_settings['add_ellipsis'] : FALSE,
-      'wordsafe' => isset($solr_field_settings['wordsafe']) ? (bool) $solr_field_settings['wordsafe'] : FALSE,
-      'wordsafe_length' => isset($solr_field_settings['wordsafe_length']) ? (int) $solr_field_settings['wordsafe_length'] : 1,
-      'enable_permissions' => isset($solr_field_settings['enable_permissions']) ? $solr_field_settings['enable_permissions'] : FALSE,
-      'permissions' => isset($solr_field_settings['permissions']) ? $solr_field_settings['permissions'] : NULL,
-      'replace_pid_with_label' => empty($solr_field_settings['replace_pid_with_label']) ? FALSE : (bool) $solr_field_settings['replace_pid_with_label'],
-      'link_to_object' => isset($solr_field_settings['link_to_object']) ? $solr_field_settings['link_to_object'] : FALSE,
-      'link_to_search' => isset($solr_field_settings['link_to_search']) ? $solr_field_settings['link_to_search'] : FALSE,
-      'weight' => isset($solr_field_settings['weight']) ? (int) $solr_field_settings['weight'] : 0,
-    ];
+      'snippet' => FALSE,
+      'date_format' => '',
+      'truncation_type' => 'separate_value_option',
+      'maximum_length' => 0,
+      'add_ellipsis' => FALSE,
+      'wordsafe' => FALSE,
+      'wordsafe_length' => 1,
+      'replace_pid_with_label' => FALSE,
+      'link_to_object' => FALSE,
+      'link_to_search' => FALSE,
+    ] + parent::fieldConfigurationDefaults();
   }
 
   /**
@@ -56,7 +38,7 @@ class ConfigureResultField extends ConfigFieldFormBase {
     $form['#suffix'] = '</div>';
 
     $form_state->setStorage(['solr_field' => $solr_field]);
-    $values = islandora_solr_get_field_configuration('result_fields', $solr_field);
+    $values = islandora_solr_get_field_configuration($this->getFieldType(), $solr_field);
 
     $form['options'] = [
       '#type' => 'container',

--- a/src/Form/ConfigureSearchField.php
+++ b/src/Form/ConfigureSearchField.php
@@ -7,18 +7,6 @@ namespace Drupal\islandora_solr\Form;
  */
 class ConfigureSearchField extends ConfigFieldFormBase {
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'islandora_solr_configure_search_field_form';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getFieldType() {
-    return 'search_fields';
-  }
+  const FIELD_TYPE = 'search_field';
 
 }

--- a/src/Form/ConfigureSortField.php
+++ b/src/Form/ConfigureSortField.php
@@ -7,18 +7,6 @@ namespace Drupal\islandora_solr\Form;
  */
 class ConfigureSortField extends ConfigFieldFormBase {
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormId() {
-    return 'islandora_solr_configure_sort_field_form';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getFieldType() {
-    return 'sort_fields';
-  }
+  const FIELD_TYPE = 'sort_field';
 
 }


### PR DESCRIPTION
Permission logic was attempting to use the old D7 numeric IDs for roles, when we have machine names and the like... also, got into DRYing out forms due to DRYing out the related schema... great fun.