### PR TITLE
Fix update hook.

### DIFF
--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -73,7 +73,7 @@ function islandora_solr_schema() {
 /**
  * Migrate old Drupal database fields into the new configuration.
  */
-function islandora_solr_update_8000() {
+function islandora_solr_update_8001() {
   $db = \Drupal::database();
   $schema = $db->schema();
   if (!$schema->tableExists('islandora_solr_fields')) {


### PR DESCRIPTION
As per [docs](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_update_N/8.6.x):

> Note that the x000 number can never be used: the lowest update number
that will be recognized and run for major version x is x001


Noticed during https://github.com/qadan/islandora_solr_metadata/pull/1