### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_solr.info.yml
+++ b/islandora_solr.info.yml
@@ -5,5 +5,5 @@ description: 'Searches an Islandora Solr index'
 package: 'Islandora Search'
 configure: islandora_solr.admin_index_settings
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module

--- a/islandora_solr_config/islandora_solr_config.info.yml
+++ b/islandora_solr_config/islandora_solr_config.info.yml
@@ -4,5 +4,5 @@ dependencies:
   - :islandora_solr
 package: 'Islandora Search'
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)